### PR TITLE
Update binary-tree-level-order-traversal.py

### DIFF
--- a/Python/binary-tree-level-order-traversal.py
+++ b/Python/binary-tree-level-order-traversal.py
@@ -40,11 +40,11 @@ class Solution(object):
             temp = []
             while l:
                 left_most = current.pop(0)
-                temp.append(left_most)
-                if node.left:
-                    result.append(node.left)
-                if node.right:
-                    result.append(node.right)
+                temp.append(left_most.val)
+                if left_most.left:
+                    current.append(left_most.left)
+                if left_most.right:
+                    current.append(left_most.right)
                 l -= 1
             result.append(temp)
         return result


### PR DESCRIPTION
Maybe replacing next_level with the length of the current stack can decrease space complexity!